### PR TITLE
now also converting lists to JSON

### DIFF
--- a/rethinkdb_fdw/rethinkdb_fdw.py
+++ b/rethinkdb_fdw/rethinkdb_fdw.py
@@ -120,6 +120,10 @@ class RethinkDBFDW(ForeignDataWrapper):
 
                     row[resultColumn] = json.dumps(resultRow[resultColumn])
 
+                elif type(resultRow[resultColumn]) is list:
+
+                    row[resultColumn] = json.dumps(resultRow[resultColumn])
+
                 else:
 
                     row[resultColumn] = resultRow[resultColumn]


### PR DESCRIPTION
Hi, this now also converts arrays to JSON in addition to dicts

before this arrays - especially text arrays - are passed as ugly python arrays which do not parse aa JSON type

they looks omething like this : "[u'hjkfhkj', ..."